### PR TITLE
Feature/local join

### DIFF
--- a/src/main/java/com/minizin/travel/config/SecurityConfig.java
+++ b/src/main/java/com/minizin/travel/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -26,6 +27,11 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
     private final TokenProvider tokenProvider;
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -75,7 +81,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/", "/auth/join", "/auth/login").permitAll()
                         .anyRequest().authenticated());
 
         //세션 설정 : STATELESS

--- a/src/main/java/com/minizin/travel/user/controller/AuthController.java
+++ b/src/main/java/com/minizin/travel/user/controller/AuthController.java
@@ -1,0 +1,43 @@
+package com.minizin.travel.user.controller;
+
+import com.minizin.travel.user.domain.dto.JoinDto;
+import com.minizin.travel.user.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/auth/jwt")
+    public ResponseEntity<?> getJwt(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("Authorization")) {
+                    String token = cookie.getValue();
+                    response.setHeader("Authorization", token);
+                    return ResponseEntity.ok("JWT 헤더로 발급");
+                }
+            }
+        }
+        return ResponseEntity.status(401).body("Unauthorized");
+    }
+
+    @PostMapping("/auth/join")
+    public JoinDto.Response join(
+            @RequestBody @Valid JoinDto.Request request
+    ) {
+        return authService.join(request);
+    }
+}

--- a/src/main/java/com/minizin/travel/user/domain/dto/JoinDto.java
+++ b/src/main/java/com/minizin/travel/user/domain/dto/JoinDto.java
@@ -1,0 +1,73 @@
+package com.minizin.travel.user.domain.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.minizin.travel.user.domain.entity.UserEntity;
+import com.minizin.travel.user.domain.enums.LoginType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class JoinDto {
+    @Getter
+    public static class Request {
+        @NotBlank
+        @Size(min = 6, max = 20, message = "Username must be between 6 and 20 characters")
+        private String username;
+
+        @NotBlank
+        @Size(min = 8, message = "Password must be at least 8 characters")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!-~]).*$",
+                message = "Password must contain at least one uppercase letter," +
+                        " one lowercase letter, one number, and one special character")
+        private String password;
+
+        private String nickname;
+
+        @NotBlank
+        @Email
+        // 64 (local) + 1 (at) + 255 (domain) = 320
+        @Size(max = 320, message = "Email must be less than 320 characters")
+        private String email;
+
+        @NotBlank
+        @Size(min = 2, max = 50, message = "Name must be between 2 and 50 characters")
+        private String name;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+        private Boolean success;
+        private Long userId;
+        private String username;
+        private String password;
+        private String nickname;
+        private String email;
+        private String name;
+        private LoginType loginType;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static Response fromUserEntity(UserEntity userEntity) {
+            return Response.builder()
+                    .success(true)
+                    .userId(userEntity.getId())
+                    .username(userEntity.getUsername())
+                    .password(userEntity.getPassword())
+                    .nickname(userEntity.getNickname())
+                    .email(userEntity.getEmail())
+                    .name(userEntity.getName())
+                    .loginType(userEntity.getLoginType())
+                    .createdAt(userEntity.getCreatedAt())
+                    .updatedAt(userEntity.getUpdatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/minizin/travel/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/minizin/travel/user/domain/entity/UserEntity.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -31,8 +32,6 @@ public class UserEntity {
     private String nickname;
 
     private String name;
-
-    private String phone;
 
     @Enumerated(EnumType.STRING)
     private LoginType loginType;

--- a/src/main/java/com/minizin/travel/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/minizin/travel/user/domain/repository/UserRepository.java
@@ -11,4 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByUsername(String username);
+
+    Boolean existsByUsername(String username);
+
 }

--- a/src/main/java/com/minizin/travel/user/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/minizin/travel/user/jwt/JwtAuthenticationFilter.java
@@ -26,12 +26,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 특정 경로 무시 (무한 루프 방지)
         String requestUri = request.getRequestURI();
-        if (requestUri.matches("^\\/login(?:\\/.*)?$")) {
-
-            filterChain.doFilter(request, response);
-            return;
-        }
-        if (requestUri.matches("^\\/oauth2(?:\\/.*)?$")) {
+        if (requestUri.matches("^\\/login(?:\\/.*)?$") ||
+                requestUri.matches("^\\/oauth2(?:\\/.*)?$") ||
+                requestUri.matches("^\\/auth\\/join(?:\\/.*)?$")) {
 
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/minizin/travel/user/service/AuthService.java
+++ b/src/main/java/com/minizin/travel/user/service/AuthService.java
@@ -1,0 +1,36 @@
+package com.minizin.travel.user.service;
+
+import com.minizin.travel.user.domain.dto.JoinDto;
+import com.minizin.travel.user.domain.entity.UserEntity;
+import com.minizin.travel.user.domain.enums.LoginType;
+import com.minizin.travel.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public JoinDto.Response join(JoinDto.Request request) {
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new RuntimeException("이미 존재하는 사용자입니다.");
+        }
+
+        UserEntity saved = userRepository.save(UserEntity.builder()
+                .username(request.getUsername())
+                .password(
+                        bCryptPasswordEncoder.encode(request.getPassword())
+                )
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .name(request.getName())
+                .loginType(LoginType.LOCAL)
+                .build());
+
+        return JoinDto.Response.fromUserEntity(saved);
+    }
+}

--- a/src/test/java/com/minizin/travel/user/service/AuthServiceTest.java
+++ b/src/test/java/com/minizin/travel/user/service/AuthServiceTest.java
@@ -1,0 +1,85 @@
+package com.minizin.travel.user.service;
+
+import com.minizin.travel.user.domain.dto.JoinDto;
+import com.minizin.travel.user.domain.entity.UserEntity;
+import com.minizin.travel.user.domain.enums.LoginType;
+import com.minizin.travel.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void join_success() {
+        //given
+        JoinDto.Request request = mock(JoinDto.Request.class);
+        when(request.getUsername()).thenReturn("username");
+        given(userRepository.existsByUsername(anyString()))
+                .willReturn(false);
+        when(request.getPassword()).thenReturn("password");
+        given(bCryptPasswordEncoder.encode(anyString()))
+                .willReturn("password");
+        given(userRepository.save(any()))
+                .willReturn(UserEntity.builder()
+                        .username("username")
+                        .password("password")
+                        .nickname("nickname")
+                        .email("local@domain.com")
+                        .name("name")
+                        .loginType(LoginType.LOCAL)
+                        .build());
+
+        //when
+        JoinDto.Response response = authService.join(request);
+
+        //then
+        assertEquals("username", response.getUsername());
+        assertEquals("password", response.getPassword());
+        assertEquals("nickname", response.getNickname());
+        assertEquals("local@domain.com", response.getEmail());
+        assertEquals("name", response.getName());
+        assertEquals(LoginType.LOCAL, response.getLoginType());
+
+        verify(userRepository, times(1)).save(any(UserEntity.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이미 존재하는 사용자")
+    void join_fail_alreadyExistsUser() {
+        //given
+        JoinDto.Request request = mock(JoinDto.Request.class);
+        when(request.getUsername()).thenReturn("username");
+        given(userRepository.existsByUsername(anyString()))
+                .willReturn(true);
+
+        //when
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> authService.join(request));
+
+        //then
+        assertEquals("이미 존재하는 사용자입니다.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
### 변경사항
- UserEntity : UserEntity에서 phone 필드가 삭제되었습니다.
- UserRepository :
  - existsByUsername : 사용자 존재 여부 확인 메소드가 추가 되었습니다.
- SecurityConfig : 
  - BCryptPasswordEncoder가 bean으로 등록되었습니다.
  - 경로별 인가 작업에 일반 회원가입 / 로그인 경로가 추가되었습니다.
- JwtAuthenticationFilter : 일반 회원가입 요청에 대해 jwt를 검증하지 않도록 설정했습니다.
- AuthController : 일반 회원가입 요청 처리 로직이 추가되었습니다.
### 추가된 내용
- JoinDto : 일반 회원가입 요청 및 응답 Dto 입니다. 유효성 검사가 적용되었습니다.
- AuthService : 일반 회원가입 로직입니다.
- AuthServiceTest : 일반 회원가입 로직에 대한 테스트 코드입니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] API 테스트 ( Post Man )
- [x] 서비스 layer Unit Test
