### PR TITLE
feat:✨ #29 select my plan list

### DIFF
--- a/src/main/java/com/minizin/travel/plan/controller/PlanController.java
+++ b/src/main/java/com/minizin/travel/plan/controller/PlanController.java
@@ -28,9 +28,9 @@ public class PlanController {
 
     // #29 2024.06.02 내 여행 일정 조회 START //
     @GetMapping("/plans")
-    public ResponseEntity<?> selectPlan(@RequestParam("cursor_id") Long cursorId) {
+    public ResponseEntity<?> selectListPlan(@RequestParam("cursor_id") Long cursorId) {
 
-        var result = planService.selectList(cursorId);
+        var result = planService.selectListPlan(cursorId);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/minizin/travel/plan/controller/PlanController.java
+++ b/src/main/java/com/minizin/travel/plan/controller/PlanController.java
@@ -26,5 +26,14 @@ public class PlanController {
     }
     // #28 2024.05.30 내 여행 일정 생성하기 END //
 
+    // #29 2024.06.02 내 여행 일정 조회 START //
+    @GetMapping("/plans")
+    public ResponseEntity<?> selectPlan(@RequestParam("cursor_id") Long cursorId) {
+
+        var result = planService.selectList(cursorId);
+
+        return ResponseEntity.ok(result);
+    }
+    // #29 2024.06.02 내 여행 일정 조회 END //
 }
 

--- a/src/main/java/com/minizin/travel/plan/dto/ListPlanDto.java
+++ b/src/main/java/com/minizin/travel/plan/dto/ListPlanDto.java
@@ -1,0 +1,64 @@
+package com.minizin.travel.plan.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.minizin.travel.plan.entity.Plan;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonPropertyOrder({"id", "userId", "planName", "theme", "startDate", "endDate", "scope", "numberOfMembers", "numberOfLikes", "numberOfScraps", "waypoints", "responseScheduleListDtos"})
+public class ListPlanDto {
+
+    @JsonProperty("plan_id")
+    private Long id;
+
+    private Long userId;
+
+    private String planName;
+
+    private String theme;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private boolean scope;
+
+    private int numberOfMembers;
+
+    private int numberOfLikes;
+
+    private int numberOfScraps;
+
+    @Setter
+    private List<String> waypoints;
+
+    @JsonProperty("schedule")
+    @Setter
+    private List<ListPlanScheduleDto> listPlanScheduleDtoList;
+
+    public static ListPlanDto toDto(Plan plan) {
+        return ListPlanDto.builder()
+                .id(plan.getId())
+                .userId(plan.getUserId())
+                .planName(plan.getPlanName())
+                .theme(plan.getTheme())
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
+                .scope(plan.isScope())
+                .numberOfMembers(plan.getNumberOfMembers())
+                .numberOfLikes(plan.getNumberOfLikes())
+                .numberOfScraps(plan.getNumberOfScraps())
+                .build();
+    }
+
+}

--- a/src/main/java/com/minizin/travel/plan/dto/ListPlanScheduleDto.java
+++ b/src/main/java/com/minizin/travel/plan/dto/ListPlanScheduleDto.java
@@ -1,0 +1,54 @@
+package com.minizin.travel.plan.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.minizin.travel.plan.entity.PlanSchedule;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+// 2024.06.05 내 여행 일정 조회 //
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonPropertyOrder({"id", "scheduleDate", "placeName", "arrivalTime", "x", "y"})
+@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ListPlanScheduleDto {
+
+    @JsonProperty("schedule_id")
+    private Long id;
+
+    private LocalDate scheduleDate;
+
+    private String placeName;
+
+    private LocalTime arrivalTime;
+
+    private Double x;
+    private Double y;
+
+    private String placeAddr;
+
+    private String placeCategory;
+
+    public static ListPlanScheduleDto toDto(PlanSchedule planSchedule) {
+        return ListPlanScheduleDto.builder()
+                .id(planSchedule.getId())
+                .scheduleDate(planSchedule.getScheduleDate())
+                .placeName(planSchedule.getPlaceName())
+                .arrivalTime(planSchedule.getArrivalTime())
+                .x(planSchedule.getX())
+                .y(planSchedule.getY())
+                .placeAddr(planSchedule.getPlaceAddr())
+                .placeCategory(planSchedule.getPlaceCategory())
+                .build();
+    }
+}
+

--- a/src/main/java/com/minizin/travel/plan/dto/PlanScheduleDto.java
+++ b/src/main/java/com/minizin/travel/plan/dto/PlanScheduleDto.java
@@ -33,5 +33,7 @@ public class PlanScheduleDto {
     private Double x;
     private Double y;
 
+    // #29 2024.06.02 내 여행 일정 조회
+    private String placeAddr;
 }
 

--- a/src/main/java/com/minizin/travel/plan/dto/ResponseListPlanDto.java
+++ b/src/main/java/com/minizin/travel/plan/dto/ResponseListPlanDto.java
@@ -1,0 +1,21 @@
+package com.minizin.travel.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+// #29 2024.06.02 내 여행 일정 조회 START //
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseListPlanDto {
+
+    List<ListPlanDto> data;
+
+    Long nextCursor;
+}
+// #29 2024.06.02 내 여행 일정 조회 END //

--- a/src/main/java/com/minizin/travel/plan/entity/PlanSchedule.java
+++ b/src/main/java/com/minizin/travel/plan/entity/PlanSchedule.java
@@ -49,6 +49,10 @@ public class PlanSchedule {
 
     private Double y;
 
+    // #29 2024.06.02 내 여행 일정 조회
+    @Column(name = "place_addr")
+    private String placeAddr;
+
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/src/main/java/com/minizin/travel/plan/service/PlanService.java
+++ b/src/main/java/com/minizin/travel/plan/service/PlanService.java
@@ -104,7 +104,7 @@ public class PlanService {
     // #28 2024.05.30 내 여행 일정 생성하기 END //
 
     // #29 2024.06.02 내 여행 일정 조회 START //
-    public ResponseListPlanDto selectList(Long cursorId) {
+    public ResponseListPlanDto selectListPlan(Long cursorId) {
 
         Pageable page = PageRequest.of(0, DEFAULT_PAGE_SIZE);
 

--- a/src/test/java/com/minizin/travel/plan/SelectListPlanTest.java
+++ b/src/test/java/com/minizin/travel/plan/SelectListPlanTest.java
@@ -1,2 +1,44 @@
-package com.minizin.travel.plan;public class SelectListPlanTest {
+package com.minizin.travel.plan;
+
+import com.minizin.travel.plan.entity.Plan;
+import com.minizin.travel.plan.repository.PlanRepository;
+import com.minizin.travel.plan.service.PlanService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class SelectListPlanTest {
+
+    private final PlanRepository planRepository;
+    private final PlanService planService;
+
+    @Autowired
+    public SelectListPlanTest(PlanRepository planRepository, PlanService planService) {
+        this.planRepository = planRepository;
+        this.planService = planService;
+    }
+
+    @Test
+    void selectListPlanTest() {
+        // given
+        for (int i = 0; i < 10; i++) {
+            planRepository.save(Plan.builder()
+                    .planName("test")
+                    .userId(1L)
+                    .build());
+        }
+
+        // when
+        Long cursorId = 10L;
+        var result = planService.selectListPlan(cursorId);
+
+        // then
+        // cursorId 보다 작은 id 값부터 조회
+        Assertions.assertEquals(9, result.getData().get(0).getId());
+        // 현재 planService 에 지정된 조회되는 개수가 6개 (id: 9 ~ 4까지 조회)
+        // nextCursor의 값은 4로 지정
+        Assertions.assertEquals(4, result.getNextCursor());
+    }
 }

--- a/src/test/java/com/minizin/travel/plan/SelectListPlanTest.java
+++ b/src/test/java/com/minizin/travel/plan/SelectListPlanTest.java
@@ -1,0 +1,2 @@
+package com.minizin.travel.plan;public class SelectListPlanTest {
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
1. placeAddr 필드 추가
PlanSchedule : 필드 추가
PlanScheduleDto : 필드 추가
PlanService 내의 createPlanSchedule : 데이터 저장

2. PlanController
selectPlanList 메소드 추가

3. PlanService
selectListPlan : 메소드 추가
duplicateWaypoints : 여행 경로가 ["서울", "서울", "부산"] 인 경우 ["서울", "부산"] 으로 생성 
findAllByCursorIdCheckExistCursor : 커서 기반 페이지를 위한 메소드(Repository 메소드는 #28 에 이미 추가됨)

4. DTO 추가
ResponseListPlanDto : FE의 요청대로 ListPlanDto를 감싸기 위한 DTO
ListPlanDto
ListPlanScheduleDto

5. Test 추가
커서 기반 페이징 테스트
cursorId 를 기준으로 그 아래 id값들의 plan 데이터 조회
(PlanService 내 지정한 개수만큼)
조회한 id를 nextCursor에 저장하여 반환

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
1. SelectListPlanTest 내에서 테스트

2. postman 으로 생성 후 조회 테스트 완료
![image](https://github.com/team-MiniJin/BE/assets/149382038/4e08b3df-820a-45a4-b477-6b9f0d001127)
