### PR TITLE
Feature/login/bug fix

### DIFF
--- a/src/main/java/com/minizin/travel/user/auth/LoginFilter.java
+++ b/src/main/java/com/minizin/travel/user/auth/LoginFilter.java
@@ -1,6 +1,7 @@
 package com.minizin.travel.user.auth;
 
 import com.minizin.travel.user.domain.dto.PrincipalDetails;
+import com.minizin.travel.user.domain.enums.Role;
 import com.minizin.travel.user.jwt.TokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -45,8 +46,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
 
         String username = principalDetails.getUsername();
+        Role role = principalDetails.getUserEntity().getRole();
 
-        String token = tokenProvider.createJwt(username, 60 * 60 * 10L);
+        String token = tokenProvider.createJwt(username, role.toString(), 60 * 60 * 10L);
 
         response.addHeader("Authorization", "Bearer " + token);
     }

--- a/src/main/java/com/minizin/travel/user/domain/dto/JoinDto.java
+++ b/src/main/java/com/minizin/travel/user/domain/dto/JoinDto.java
@@ -4,18 +4,21 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.minizin.travel.user.domain.entity.UserEntity;
 import com.minizin.travel.user.domain.enums.LoginType;
+import com.minizin.travel.user.domain.enums.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class JoinDto {
     @Getter
+    @Setter
     public static class Request {
         @NotBlank
         @Size(min = 6, max = 20, message = "Username must be between 6 and 20 characters")
@@ -36,9 +39,6 @@ public class JoinDto {
         @Size(max = 320, message = "Email must be less than 320 characters")
         private String email;
 
-        @NotBlank
-        @Size(min = 2, max = 50, message = "Name must be between 2 and 50 characters")
-        private String name;
     }
 
     @Getter
@@ -50,7 +50,7 @@ public class JoinDto {
         private String password;
         private String nickname;
         private String email;
-        private String name;
+        private Role role;
         private LoginType loginType;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
@@ -63,7 +63,7 @@ public class JoinDto {
                     .password(userEntity.getPassword())
                     .nickname(userEntity.getNickname())
                     .email(userEntity.getEmail())
-                    .name(userEntity.getName())
+                    .role(userEntity.getRole())
                     .loginType(userEntity.getLoginType())
                     .createdAt(userEntity.getCreatedAt())
                     .updatedAt(userEntity.getUpdatedAt())

--- a/src/main/java/com/minizin/travel/user/domain/dto/PrincipalDetails.java
+++ b/src/main/java/com/minizin/travel/user/domain/dto/PrincipalDetails.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
@@ -23,7 +24,9 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add((GrantedAuthority) () -> userEntity.getRole().toString());
+        return collection;
     }
 
     @Override

--- a/src/main/java/com/minizin/travel/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/minizin/travel/user/domain/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package com.minizin.travel.user.domain.entity;
 
 import com.minizin.travel.user.domain.enums.LoginType;
+import com.minizin.travel.user.domain.enums.Role;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -31,7 +32,8 @@ public class UserEntity {
     @Setter
     private String nickname;
 
-    private String name;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     @Enumerated(EnumType.STRING)
     private LoginType loginType;

--- a/src/main/java/com/minizin/travel/user/domain/enums/Role.java
+++ b/src/main/java/com/minizin/travel/user/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package com.minizin.travel.user.domain.enums;
+
+public enum Role {
+    ROLE_USER,
+}

--- a/src/main/java/com/minizin/travel/user/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/minizin/travel/user/oauth2/CustomSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.minizin.travel.user.oauth2;
 
 import com.minizin.travel.user.domain.dto.PrincipalDetails;
+import com.minizin.travel.user.domain.enums.Role;
 import com.minizin.travel.user.jwt.TokenProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -26,8 +27,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
 
         String username = principalDetails.getUsername();
+        Role role = principalDetails.getUserEntity().getRole();
 
-        String token = tokenProvider.createJwt(username, 60 * 60 * 60L);
+        String token = tokenProvider.createJwt(username, role.toString(), 60 * 60 * 60L);
 
         // 응답에 쿠키로 jwt 발급
         response.addCookie(createCookie("Authorization", token));

--- a/src/main/java/com/minizin/travel/user/service/AuthService.java
+++ b/src/main/java/com/minizin/travel/user/service/AuthService.java
@@ -3,6 +3,7 @@ package com.minizin.travel.user.service;
 import com.minizin.travel.user.domain.dto.JoinDto;
 import com.minizin.travel.user.domain.entity.UserEntity;
 import com.minizin.travel.user.domain.enums.LoginType;
+import com.minizin.travel.user.domain.enums.Role;
 import com.minizin.travel.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -27,7 +28,7 @@ public class AuthService {
                 )
                 .nickname(request.getNickname())
                 .email(request.getEmail())
-                .name(request.getName())
+                .role(Role.ROLE_USER)
                 .loginType(LoginType.LOCAL)
                 .build());
 

--- a/src/main/java/com/minizin/travel/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/minizin/travel/user/service/CustomOAuth2UserService.java
@@ -4,6 +4,7 @@ import com.minizin.travel.user.domain.dto.KakaoResponse;
 import com.minizin.travel.user.domain.dto.PrincipalDetails;
 import com.minizin.travel.user.domain.entity.UserEntity;
 import com.minizin.travel.user.domain.enums.LoginType;
+import com.minizin.travel.user.domain.enums.Role;
 import com.minizin.travel.user.domain.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +48,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                     .username(username)
                     .email(kakaoResponse.getEmail())
                     .nickname(kakaoResponse.getNickname())
+                    .role(Role.ROLE_USER)
                     .loginType(LoginType.KAKAO)
                     .build());
         } else {

--- a/src/test/java/com/minizin/travel/user/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/minizin/travel/user/service/CustomOAuth2UserServiceTest.java
@@ -3,6 +3,7 @@ package com.minizin.travel.user.service;
 import com.minizin.travel.user.domain.dto.PrincipalDetails;
 import com.minizin.travel.user.domain.entity.UserEntity;
 import com.minizin.travel.user.domain.enums.LoginType;
+import com.minizin.travel.user.domain.enums.Role;
 import com.minizin.travel.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -40,10 +40,10 @@ class CustomOAuth2UserServiceTest {
     @DisplayName("소셜 로그인 시 사용자 정보 획득 성공")
     void loadUser_success() {
         //given
-        OAuth2User oAuth2User = mock(OAuth2User.class);
-        given(delegate.loadUser(any())).willReturn(oAuth2User);
-
         OAuth2UserRequest userRequest = mock(OAuth2UserRequest.class);
+        OAuth2User oAuth2User = mock(OAuth2User.class);
+        given(delegate.loadUser(userRequest)).willReturn(oAuth2User);
+
         ClientRegistration clientRegistration = mock(ClientRegistration.class);
         when(userRequest.getClientRegistration()).thenReturn(clientRegistration);
         when(clientRegistration.getRegistrationId()).thenReturn("kakao");
@@ -56,13 +56,14 @@ class CustomOAuth2UserServiceTest {
                 )
         );
         when(oAuth2User.getAttributes()).thenReturn(attributes);
-        given(userRepository.findByUsername(anyString()))
+        given(userRepository.findByUsername("kakao 12345"))
                 .willReturn(Optional.empty());
-        given(userRepository.save(any()))
+        given(userRepository.save(any(UserEntity.class)))
                 .willReturn(UserEntity.builder()
                         .username("kakao 12345")
                         .email("test@example.com")
                         .nickname("Test User")
+                        .role(Role.ROLE_USER)
                         .loginType(LoginType.KAKAO)
                         .build());
 

--- a/src/test/java/com/minizin/travel/user/service/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/minizin/travel/user/service/CustomUserDetailsServiceTest.java
@@ -3,6 +3,7 @@ package com.minizin.travel.user.service;
 import com.minizin.travel.user.domain.dto.PrincipalDetails;
 import com.minizin.travel.user.domain.entity.UserEntity;
 import com.minizin.travel.user.domain.enums.LoginType;
+import com.minizin.travel.user.domain.enums.Role;
 import com.minizin.travel.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,14 +32,14 @@ class CustomUserDetailsServiceTest {
     @DisplayName("username 으로 principalDetails 획득 성공")
     void loadUserByUsername_success() {
         //given
-        given(userRepository.findByUsername(anyString()))
+        given(userRepository.findByUsername("username"))
                 .willReturn(Optional.of(
                         UserEntity.builder()
                                 .username("username")
                                 .password("password")
                                 .email("email")
-                                .name("name")
                                 .nickname("nickname")
+                                .role(Role.ROLE_USER)
                                 .loginType(LoginType.LOCAL)
                                 .build()
                 ));
@@ -51,8 +51,8 @@ class CustomUserDetailsServiceTest {
         assertEquals("username", ((PrincipalDetails) userDetails).getUserEntity().getUsername());
         assertEquals("password", ((PrincipalDetails) userDetails).getUserEntity().getPassword());
         assertEquals("email", ((PrincipalDetails) userDetails).getUserEntity().getEmail());
-        assertEquals("name", ((PrincipalDetails) userDetails).getUserEntity().getName());
         assertEquals("nickname", ((PrincipalDetails) userDetails).getUserEntity().getNickname());
+        assertEquals(Role.ROLE_USER, ((PrincipalDetails) userDetails).getUserEntity().getRole());
         assertEquals(LoginType.LOCAL, ((PrincipalDetails) userDetails).getUserEntity().getLoginType());
     }
 
@@ -60,7 +60,7 @@ class CustomUserDetailsServiceTest {
     @DisplayName("username 으로 principalDetails 획득 실패 - 존재하지 않는 사용자")
     void loadUserByUsername_fail_UserNotFound() {
         //given
-        given(userRepository.findByUsername(anyString()))
+        given(userRepository.findByUsername("username"))
                 .willReturn(Optional.empty());
 
         //when


### PR DESCRIPTION
### 변경사항
java.lang.IllegalArgumentException: Cannot pass null or empty values to constructor
: 스프링 시큐리티 인증 토큰 생성 시 Authentication 객체 필드에 null이 있을 경우 생기는 에러입니다.

- UserEntity의 name 필드가 삭제되었습니다.
- 권한 정보를 따로 설정해주지 않았던 기존 UserEntity에 role 필드가 추가되었습니다.
- 이제 jwt 발급 로직에 username 과 role 이 사용됩니다.

### 테스트
- [x] API 테스트 ( Post Man )
- [x] AuthService, CustomOAuth2UserService, CustomUserDetailsService Unit Test