### PR TITLE
fix:🐛 #151 조회할 데이터가 없을 시 next_cursor 필드 제거

### DIFF
--- a/src/main/java/com/minizin/travel/plan/repository/PlanRepository.java
+++ b/src/main/java/com/minizin/travel/plan/repository/PlanRepository.java
@@ -15,6 +15,8 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     List<Plan> findAllByUserIdOrderByIdDesc(Long userId, Pageable pageable);
 
+    boolean existsByIdLessThan(Long id);
+
     // #39 2024.06.10 다가오는 여행 일정 조회 //
     List<Plan> findTop6ByUserIdAndStartDateAfterOrderByStartDateAsc(Long userId, LocalDate today);
 

--- a/src/main/java/com/minizin/travel/plan/service/PlanService.java
+++ b/src/main/java/com/minizin/travel/plan/service/PlanService.java
@@ -192,6 +192,10 @@ public class PlanService {
             listPlanDtoList.add(selectListPlanDto);
         }
 
+        if (!planRepository.existsByIdLessThan(planId)) {
+            planId = null;
+        }
+
         return ResponseSelectListPlanDto.builder()
                 .data(listPlanDtoList)
                 .nextCursor(planId)


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
웹 화면에서 무한 스크롤 된다는 의견에 따라
조회할 데이터가 없을 시에는 next_cursor 필드를 제거합니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

Postman 을 이용한 API 테스트 완료
로컬 빌드 완료