### PR TITLE
fix:🐛 삭제 시 파라미터로 plan id를 받아올 수 있게 변경

### DIFF
--- a/src/main/java/com/minizin/travel/scrap/controller/ScrapController.java
+++ b/src/main/java/com/minizin/travel/scrap/controller/ScrapController.java
@@ -36,11 +36,11 @@ public class ScrapController {
     // #50 스크랩 조회 END //
 
     // #51 스크랩 삭제 START //
-    @DeleteMapping("/scraps/{scrap_id}")
-    public ResponseEntity<?> deleteScrapedPlan(@PathVariable("scrap_id") Long scrapId,
+    @DeleteMapping("/scraps/{plan_id}")
+    public ResponseEntity<?> deleteScrapedPlan(@PathVariable("plan_id") Long planId,
                                                @AuthenticationPrincipal PrincipalDetails user) {
 
-        var result = scrapService.deleteScrapedPlan(scrapId, user);
+        var result = scrapService.deleteScrapedPlan(planId, user);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/minizin/travel/scrap/dto/ResponseDeleteScrapedPlanDto.java
+++ b/src/main/java/com/minizin/travel/scrap/dto/ResponseDeleteScrapedPlanDto.java
@@ -1,11 +1,13 @@
 package com.minizin.travel.scrap.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResponseDeleteScrapedPlanDto {
 
     private boolean success;

--- a/src/main/java/com/minizin/travel/scrap/dto/ResponseSelectScrapedPlansDto.java
+++ b/src/main/java/com/minizin/travel/scrap/dto/ResponseSelectScrapedPlansDto.java
@@ -19,8 +19,6 @@ public class ResponseSelectScrapedPlansDto {
 
     private Long cursorId;
 
-    private boolean success;
-
     private String message;
 
     @JsonProperty("scrap_id")
@@ -29,7 +27,6 @@ public class ResponseSelectScrapedPlansDto {
     public static ResponseSelectScrapedPlansDto fail(String message) {
 
         return ResponseSelectScrapedPlansDto.builder()
-                .success(false)
                 .message(message)
                 .build();
     }

--- a/src/main/java/com/minizin/travel/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/minizin/travel/scrap/repository/ScrapRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
@@ -18,4 +19,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     List<Scrap> findAllByUserIdOrderByIdDesc(Long userId, Pageable page);
 
     List<Scrap> findByIdLessThanAndUserIdOrderByIdDesc(Long cursorId, Long userId, Pageable page);
+
+    // #51 스크랩 삭제 전 삭제할 스크랩이 있는지 조회
+    Optional<Scrap> findByPlanIdAndUserId(Long planId, Long userId);
 }

--- a/src/main/java/com/minizin/travel/scrap/service/ScrapService.java
+++ b/src/main/java/com/minizin/travel/scrap/service/ScrapService.java
@@ -111,39 +111,29 @@ public class ScrapService {
 
     // #51 스크랩 삭제 START //
     @Transactional
-    public ResponseDeleteScrapedPlanDto deleteScrapedPlan(Long scrapId, PrincipalDetails user) {
+    public ResponseDeleteScrapedPlanDto deleteScrapedPlan(Long planId, PrincipalDetails user) {
 
         Long userId = userRepository.findByUsername(user.getUsername()).get().getId();
 
-        if (!scrapRepository.existsById(scrapId)) {
+        if (!scrapRepository.existsByPlanIdAndUserId(planId, userId)) {
 
             return ResponseDeleteScrapedPlanDto.builder()
                     .success(false)
                     .message("존재하지 않는 scrap 입니다.")
-                    .scrapId(scrapId)
                     .build();
         }
 
-        Scrap scrap = scrapRepository.findById(scrapId).get();
+        Scrap scrap = scrapRepository.findByPlanIdAndUserId(planId, userId).get();
 
-        if (scrap.getUserId().equals(userId)) {
-
-            return ResponseDeleteScrapedPlanDto.builder()
-                    .success(false)
-                    .message("로그인한 사용자가 북마크한 plan 이 아닙니다.")
-                    .scrapId(scrapId)
-                    .build();
-        }
-        Long planId = scrapRepository.findById(scrapId).get().getPlanId();
-        Plan plan = planRepository.findById(planId).get();
+        Plan plan = planRepository.findById(scrap.getPlanId()).get();
         plan.setNumberOfScraps(plan.getNumberOfScraps() - 1);
 
-        scrapRepository.deleteById(scrapId);
+        scrapRepository.deleteById(scrap.getId());
 
         return ResponseDeleteScrapedPlanDto.builder()
                 .success(true)
                 .message("Scrap Deleted Successfully")
-                .scrapId(scrapId)
+                .scrapId(scrap.getId())
                 .build();
     }
     // #51 스크랩 삭제 END //


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
기존, 스크랩을 삭제하기 위해서는 Plan id가 필요

**TO-BE**
스크랩을 삭제하기 위해서는 Plan id 필요
해당 Plan id 를 로그인한 사용자가 스크랩했는지 확인 후
스크랩 내역 삭제

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
