### PR TITLE
fix:🐛 api-tour detailcommon overview가 없는 data만 가져와서 실행

### DIFF
--- a/src/main/java/com/minizin/travel/tour/domain/repository/TourAPIRepository.java
+++ b/src/main/java/com/minizin/travel/tour/domain/repository/TourAPIRepository.java
@@ -35,7 +35,7 @@ public interface TourAPIRepository extends JpaRepository<TourAPI, Long> {
     @Query("SELECT DISTINCT t FROM TourAPI t WHERE t.addr1 LIKE CONCAT('%', :keyword, '%')")
     List<TourAPI> findDistinctSearchKeyword(@Param("keyword") String keyword, Pageable pageable);
 
-    @Query("SELECT t FROM TourAPI t WHERE t.contentId IS NOT NULL AND t.contentId != '' GROUP BY t.contentId ORDER BY t.overview")
+    @Query("SELECT t FROM TourAPI t WHERE t.contentId IS NOT NULL AND t.contentId != '' AND t.overview = '' GROUP BY t.contentId")
     Page<TourAPI> findAll(Pageable pageable);
 
 }


### PR DESCRIPTION
기존 overview가 있는 data에도 detailcommon 서비스를 실행하여 공공데이터에서 DB에 detailcommon을 저장하는데 문제가 생김 해당 error 를 sql가져오는 명령어 수정으로 해결

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
